### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Forklift
 ========
 
 .. image:: https://readthedocs.org/projects/forklift/badge/?version=latest
-    :target: https://forklift.readthedocs.org/
+    :target: https://forklift.readthedocs.io/
     :alt: Latest Docs
 
 .. image:: https://travis-ci.org/pypa/forklift.svg?branch=master
@@ -54,7 +54,7 @@ You can also join ``#pypa`` or ``#pypa-dev`` on Freenode to ask questions or
 get involved.
 
 
-.. _`documentation`: https://forklift.readthedocs.org/
+.. _`documentation`: https://forklift.readthedocs.io/
 .. _`issue tracker`: https://github.com/pypa/warehouse/issues
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
